### PR TITLE
hide sensitive information from ever being debug-logged

### DIFF
--- a/crates/gitbutler-core/src/project_repository/repository.rs
+++ b/crates/gitbutler-core/src/project_repository/repository.rs
@@ -392,7 +392,7 @@ impl Repository {
 
         let mut push_options = git2::PushOptions::new();
         push_options.remote_callbacks(callbacks);
-        let auth_header = format!("Authorization: {}", access_token);
+        let auth_header = format!("Authorization: {}", access_token.0);
         let headers = &[auth_header.as_str()];
         push_options.custom_headers(headers);
 

--- a/crates/gitbutler-core/src/types/mod.rs
+++ b/crates/gitbutler-core/src/types/mod.rs
@@ -1,1 +1,10 @@
 pub mod default_true;
+
+/// A type to clearly mark sensitive information using the type-system. As such, it should
+///
+/// * *not* be logged
+/// * *not* be stored in plain text
+/// * *not* be presented in any way unless the user explicitly confirmed it to be displayed.
+pub struct Sensitive<T>(pub T);
+
+mod sensitive;

--- a/crates/gitbutler-core/src/types/sensitive.rs
+++ b/crates/gitbutler-core/src/types/sensitive.rs
@@ -1,0 +1,69 @@
+use crate::types::Sensitive;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::ops::{Deref, DerefMut};
+
+impl<T> Serialize for Sensitive<T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+impl<'de, T> Deserialize<'de> for Sensitive<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        T::deserialize(deserializer).map(Sensitive)
+    }
+}
+
+impl<T> std::fmt::Debug for Sensitive<T>
+where
+    T: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt("<redacted>", f)
+    }
+}
+
+impl<T> Default for Sensitive<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        Self(T::default())
+    }
+}
+
+impl<T> Deref for Sensitive<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for Sensitive<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> Clone for Sensitive<T>
+where
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T> Copy for Sensitive<T> where T: Copy {}

--- a/crates/gitbutler-core/src/users/user.rs
+++ b/crates/gitbutler-core/src/users/user.rs
@@ -1,3 +1,4 @@
+use crate::types::Sensitive;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
@@ -11,9 +12,9 @@ pub struct User {
     pub locale: Option<String>,
     pub created_at: String,
     pub updated_at: String,
-    pub access_token: String,
+    pub access_token: Sensitive<String>,
     pub role: Option<String>,
-    pub github_access_token: Option<String>,
+    pub github_access_token: Option<Sensitive<String>>,
     #[serde(default)]
     pub github_username: Option<String>,
 }

--- a/crates/gitbutler-core/tests/git/credentials.rs
+++ b/crates/gitbutler-core/tests/git/credentials.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
+use std::str;
 
+use gitbutler_core::types::Sensitive;
 use gitbutler_core::{
     git::credentials::{Credential, Helper, SshCredential},
     keys, project_repository, projects, users,
@@ -10,7 +12,7 @@ use gitbutler_testsupport::{temp_dir, test_repository};
 #[derive(Default)]
 struct TestCase<'a> {
     remote_url: &'a str,
-    github_access_token: Option<&'a str>,
+    github_access_token: Option<Sensitive<&'a str>>,
     preferred_key: projects::AuthKey,
 }
 
@@ -20,7 +22,7 @@ impl TestCase<'_> {
 
         let users = users::Controller::from_path(local_app_data.path());
         let user = users::User {
-            github_access_token: self.github_access_token.map(ToString::to_string),
+            github_access_token: self.github_access_token.map(|s| Sensitive(s.0.to_string())),
             ..Default::default()
         };
         users.set_user(&user).unwrap();
@@ -54,7 +56,7 @@ mod not_github {
         fn https() {
             let test_case = TestCase {
                 remote_url: "https://gitlab.com/test-gitbutler/test.git",
-                github_access_token: Some("token"),
+                github_access_token: Some(Sensitive("token")),
                 preferred_key: projects::AuthKey::Local {
                     private_key_path: PathBuf::from("/tmp/id_rsa"),
                 },
@@ -78,7 +80,7 @@ mod not_github {
         fn ssh() {
             let test_case = TestCase {
                 remote_url: "git@gitlab.com:test-gitbutler/test.git",
-                github_access_token: Some("token"),
+                github_access_token: Some(Sensitive("token")),
                 preferred_key: projects::AuthKey::Local {
                     private_key_path: PathBuf::from("/tmp/id_rsa"),
                 },
@@ -113,7 +115,7 @@ mod github {
             fn https() {
                 let test_case = TestCase {
                     remote_url: "https://github.com/gitbutlerapp/gitbutler.git",
-                    github_access_token: Some("token"),
+                    github_access_token: Some(Sensitive("token")),
                     preferred_key: projects::AuthKey::Local {
                         private_key_path: PathBuf::from("/tmp/id_rsa"),
                     },
@@ -137,7 +139,7 @@ mod github {
             fn ssh() {
                 let test_case = TestCase {
                     remote_url: "git@github.com:gitbutlerapp/gitbutler.git",
-                    github_access_token: Some("token"),
+                    github_access_token: Some(Sensitive("token")),
                     preferred_key: projects::AuthKey::Local {
                         private_key_path: PathBuf::from("/tmp/id_rsa"),
                     },

--- a/crates/gitbutler-core/tests/types/mod.rs
+++ b/crates/gitbutler-core/tests/types/mod.rs
@@ -1,4 +1,5 @@
 use gitbutler_core::types::default_true::DefaultTrue;
+use gitbutler_core::types::Sensitive;
 
 #[test]
 #[allow(clippy::bool_assert_comparison)]
@@ -16,4 +17,10 @@ fn default_true() {
     let mut default_true = DefaultTrue::default();
     *default_true = false;
     assert!(!default_true);
+}
+
+#[test]
+fn sensitive_does_not_debug_print_itself() {
+    let s = Sensitive("password");
+    assert_eq!(format!("{s:?}"), "\"<redacted>\"");
 }

--- a/crates/gitbutler-testsupport/src/suite.rs
+++ b/crates/gitbutler-testsupport/src/suite.rs
@@ -4,6 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use gitbutler_core::types::Sensitive;
 use gitbutler_core::{git::RepositoryExt, project_repository};
 use tempfile::{tempdir, TempDir};
 
@@ -50,7 +51,7 @@ impl Suite {
         let user = gitbutler_core::users::User {
             name: Some("test".to_string()),
             email: "test@email.com".to_string(),
-            access_token: "token".to_string(),
+            access_token: Sensitive("token".to_string()),
             ..Default::default()
         };
         self.users.set_user(&user).expect("failed to add user");


### PR DESCRIPTION
### Tasks

* [x] prevent logging of sensitive data
* [x] *ideally* store sensitive data in a password store
* [x] sort out migration from old to new form of storing passwords
* [x] figure out how to purge old logs that may still contain passwords
    - [x] from the user's local logfiles
    - [x] from server-side logs that were received using the reporting function
* [ ] an incident report to inform people, and let them know which version to use so it's fixed?

### In Logs

Sensitive fields now print themselves as `redacted`.

```
2024-06-09T06:55:01.482303Z  INFO set_user: crates/gitbutler-tauri/src/users.rs:24: close time.busy=528µs time.idle=74.0µs user=User { id: 35, name: None, given_name: None, family_name: None, email: "sebastian.thiel@icloud.com", picture: "https://s.gravatar.com/avatar/09d3828c9ccf877eacd1a1de7fc6dc74?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Fse.png", locale: None, created_at: "2024-06-09T06:50:40Z", updated_at: "2024-06-09T06:55:00Z", access_token: "<redacted>", role: None, github_access_token: None, github_username: None }
```